### PR TITLE
Add Alt+F10 shortcut for "Init existing" command

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -80,7 +80,7 @@ fn new() -> evscode::R<()> {
 	Ok(())
 }
 
-#[evscode::command(title = "ICIE Init existing")]
+#[evscode::command(title = "ICIE Init existing", key = "alt+f10")]
 fn existing() -> evscode::R<()> {
 	let _status = crate::STATUS.push("Initializing");
 	let root = evscode::workspace_root()?;


### PR DESCRIPTION
I've checked and, for me, there aren't any conflicts with this keyword.

The choice was Alt+F10 because it is close to Alt+F11 and Alt+F12, already used by the extension.

Besides that, I think that when issuing this command, we should delete any previous test cases present in the directory.